### PR TITLE
feat: adapt bridge to webrtc base

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -42,7 +42,9 @@ int main(int argc, char** argv)
         std::shared_ptr<Rusty> rusty = make_shared<Rusty>(rusty_config,
             rusty_host,
             rock_peer_id,
-            deep_trekker_peer_id);
+            deep_trekker_peer_id,
+            base::Time::fromSeconds(2),
+            base::Time());
 
         rusty->waitClientNew();
 

--- a/src/Rusty.cpp
+++ b/src/Rusty.cpp
@@ -36,7 +36,15 @@ void Rusty::open()
     m_ws.open("ws://" + m_host + "?user=" + m_deep_trekker_peer_id, m_timeout);
     m_ws.onJSONMessage([&](Json::Value const& msg) {
         auto action = msg["action"].asString();
-        if (action == "open") {
+        if (action == "request-offer") {
+            {
+                unique_lock lock(m_poll_lock);
+                if (!m_client.lock()) {
+                    m_has_new_client = true;
+                }
+            }
+        }
+        else if (action == "open") {
             {
                 unique_lock lock(m_poll_lock);
                 m_client.reset();

--- a/src/Rusty.cpp
+++ b/src/Rusty.cpp
@@ -10,12 +10,14 @@ Rusty::Rusty(WebSocket::Configuration const& config,
     string const& host,
     string const& rock_peer_id,
     string const& deep_trekker_peer_id,
-    base::Time const& timeout)
+    base::Time const& timeout,
+    base::Time const& client_ping_timeout)
     : m_ws(config, "rock")
     , m_host(host)
     , m_rock_peer_id(rock_peer_id)
     , m_deep_trekker_peer_id(deep_trekker_peer_id)
     , m_timeout(timeout)
+    , m_client_ping_timeout(client_ping_timeout)
 {
     open();
 }
@@ -57,9 +59,10 @@ void Rusty::open()
             return;
         }
 
+        if (!m_client_ping_timeout.isNull())
         {
             unique_lock lock(m_poll_lock);
-            m_client_ping_deadline = Time::now() + m_timeout;
+            m_client_ping_deadline = Time::now() + m_client_ping_timeout;
         }
 
         if (action == "ping") {

--- a/src/Rusty.hpp
+++ b/src/Rusty.hpp
@@ -18,6 +18,7 @@ namespace deep_trekker {
         std::string m_rock_peer_id;
         std::string m_deep_trekker_peer_id;
         base::Time m_timeout;
+        base::Time m_client_ping_timeout;
         base::Time m_client_ping_deadline;
 
         std::shared_ptr<WebRTCNegotiationInterface> m_client_main;
@@ -36,7 +37,8 @@ namespace deep_trekker {
             std::string const& host,
             std::string const& rusty_peer_id,
             std::string const& deep_trekker_peer_id,
-            base::Time const& timeout = base::Time::fromSeconds(2));
+            base::Time const& timeout = base::Time::fromSeconds(2),
+            base::Time const& client_ping_timeout = base::Time::fromSeconds(2));
         ~Rusty();
 
         enum PollStatus {


### PR DESCRIPTION
This adapts the rustysignal-side protocol to the one that is defined by webrtc_base (and implemented in drivers/orogen/webrtc_rustysignal). It should retain compatibility with what comms_webrtc does.