### PR TITLE
fix: change directions of X/Y/Z/Yaw commands to match the body-frame conventions

### DIFF
--- a/src/CommandAndStateMessageParser.cpp
+++ b/src/CommandAndStateMessageParser.cpp
@@ -262,9 +262,9 @@ string CommandAndStateMessageParser::parseDriveRevolutionCommandMessage(
         max(abs(command.z()), minimum_vertical_command) * vertical_cmd_sign;
     auto thrust = root["drive"]["thrust"];
     thrust["forward"] = round(min(max(command.linear.x(), -1.0), 1.0) * 100);
-    thrust["lateral"] = round(min(max(command.linear.y(), -1.0), 1.0) * 100);
-    thrust["vertical"] = round(min(max(vertical_cmd, -1.0), 1.0) * 100);
-    thrust["yaw"] = round(min(max(command.angular.z(), -1.0), 1.0) * 100);
+    thrust["lateral"] = -round(min(max(command.linear.y(), -1.0), 1.0) * 100);
+    thrust["vertical"] = -round(min(max(vertical_cmd, -1.0), 1.0) * 100);
+    thrust["yaw"] = -round(min(max(command.angular.z(), -1.0), 1.0) * 100);
     root["drive"]["thrust"] = thrust;
 
     message["payload"]["devices"][address] = root;
@@ -405,9 +405,9 @@ samples::RigidBodyState CommandAndStateMessageParser::getRevolutionDriveStates(
     validateDriveStates(address);
     auto msg_setpoint = m_json_data["payload"]["devices"][address]["drive"]["thrust"];
     double setpoint_x = msg_setpoint["forward"].asDouble();
-    double setpoint_y = msg_setpoint["lateral"].asDouble();
-    double setpoint_z = msg_setpoint["vertical"].asDouble();
-    double setpoint_yaw = msg_setpoint["yaw"].asDouble();
+    double setpoint_y = -msg_setpoint["lateral"].asDouble();
+    double setpoint_z = -msg_setpoint["vertical"].asDouble();
+    double setpoint_yaw = -msg_setpoint["yaw"].asDouble();
 
     samples::RigidBodyState control;
     control.position.x() = setpoint_x;
@@ -440,7 +440,7 @@ samples::RigidBodyState CommandAndStateMessageParser::getRevolutionPoseZAttitude
     double state_z = local_frame["depth"].asDouble();
     double roll = local_frame["roll"].asDouble() * M_PI / 180;
     double pitch = local_frame["pitch"].asDouble() * M_PI / 180;
-    double yaw = local_frame["heading"].asDouble() * M_PI / 180;
+    double yaw = -local_frame["heading"].asDouble() * M_PI / 180;
 
     samples::RigidBodyState pose;
     pose.time = Time::now();

--- a/test/test_CommandAndStateMessageParser.cpp
+++ b/test/test_CommandAndStateMessageParser.cpp
@@ -169,9 +169,9 @@ TEST_F(MessageParserTest, it_parses_drive_revolution_command)
 
     auto drive = json_value["payload"]["devices"][address]["drive"];
     ASSERT_EQ(drive["thrust"]["forward"].asDouble(), 4);
-    ASSERT_EQ(drive["thrust"]["lateral"].asDouble(), 42);
-    ASSERT_EQ(drive["thrust"]["vertical"].asDouble(), 6);
-    ASSERT_EQ(drive["thrust"]["yaw"].asDouble(), 1);
+    ASSERT_EQ(drive["thrust"]["lateral"].asDouble(), -42);
+    ASSERT_EQ(drive["thrust"]["vertical"].asDouble(), -6);
+    ASSERT_EQ(drive["thrust"]["yaw"].asDouble(), -1);
 }
 
 TEST_F(MessageParserTest, it_parses_drive_mode_revolution_command)
@@ -272,7 +272,7 @@ TEST_F(MessageParserTest, it_returns_the_rov_pose_with_z_and_attitude)
 
     ASSERT_NEAR(-20, actual.position.z(), 0.01);
     ASSERT_NEAR(0.349, getRoll(actual.orientation), 0.01);
-    ASSERT_NEAR(1.5708, getYaw(actual.orientation), 0.01);
+    ASSERT_NEAR(-1.5708, getYaw(actual.orientation), 0.01);
     ASSERT_NEAR(0.1745, getPitch(actual.orientation), 0.01);
 }
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-deep_trekker/pull/9