### PR TITLE
fix: change camera head tilt to yaw

### DIFF
--- a/src/CommandAndStateMessageParser.cpp
+++ b/src/CommandAndStateMessageParser.cpp
@@ -570,8 +570,8 @@ RigidBodyState CommandAndStateMessageParser::getCameraHeadTiltMotorStateRBS(
 
     RigidBodyState rbs;
     rbs.time = Time::now();
-    auto pitch = root["tilt"]["position"].asDouble() * M_PI / 180;
-    rbs.orientation = AngleAxisd(pitch, Vector3d::UnitY());
+    auto yaw = root["tilt"]["position"].asDouble() * M_PI / 180;
+    rbs.orientation = AngleAxisd(yaw, Vector3d::UnitZ());
     return rbs;
 }
 


### PR DESCRIPTION
In the ROV sdf model, the front camera joint is rotated 90 deg, that requires the tilt to be represented as a yaw, not a pitch.