### PR TITLE
fix: remove compensated command from revolution struct

### DIFF
--- a/src/DeepTrekkerStates.hpp
+++ b/src/DeepTrekkerStates.hpp
@@ -202,7 +202,6 @@ namespace deep_trekker {
         power_base::BatteryStatus left_battery;
         power_base::BatteryStatus right_battery;
         float cpu_temperature;
-        base::commands::LinearAngular6DCommand compensated_command;
     };
 
     /**


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-orogen-deep_trekker/pull/18

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
This parameter is now reported by a separate port.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [x] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
