### PR TITLE
fix: set cov matrixes to defined values

### DIFF
--- a/src/CommandAndStateMessageParser.cpp
+++ b/src/CommandAndStateMessageParser.cpp
@@ -484,9 +484,12 @@ samples::RigidBodyState CommandAndStateMessageParser::getRevolutionPoseZAttitude
     samples::RigidBodyState pose;
     pose.time = Time::now();
     pose.position.z() = -state_z;
+    pose.cov_position(2, 2) = 1e-1;
     pose.orientation = AngleAxisd(yaw, Vector3d::UnitZ()) *
                        AngleAxisd(pitch, Vector3d::UnitY()) *
                        AngleAxisd(roll, Vector3d::UnitX());
+    // 1 degree squared in radians
+    pose.cov_orientation = Matrix3d::Identity() * pow(0.0174533, 2);
 
     return pose;
 }

--- a/test/test_CommandAndStateMessageParser.cpp
+++ b/test/test_CommandAndStateMessageParser.cpp
@@ -345,6 +345,11 @@ TEST_F(MessageParserTest, it_returns_the_rov_pose_with_z_and_attitude)
     ASSERT_NEAR(0.349, getRoll(actual.orientation), 0.01);
     ASSERT_NEAR(-1.5708, getYaw(actual.orientation), 0.01);
     ASSERT_NEAR(0.1745, getPitch(actual.orientation), 0.01);
+    ASSERT_NEAR(0.1, actual.cov_position(2, 2), 0.01);
+    ASSERT_NEAR(0.0003046, actual.cov_orientation(0, 0), 1e-5);
+    ASSERT_NEAR(0.0003046, actual.cov_orientation(0, 0), 1e-5);
+    ASSERT_NEAR(0.0003046, actual.cov_orientation(1, 1), 1e-5);
+    ASSERT_NEAR(0.0003046, actual.cov_orientation(2, 2), 1e-5);
 }
 
 TEST_F(MessageParserTest, it_returns_the_drive_mode)


### PR DESCRIPTION

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
The filters used on pose_estimation need the covariance for position and orientation. 

For Z, the choice was 0.1m. For orientation, we used 1 deg in radians squared. These are just educated guesses after operating with the ROV.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Uni tests

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [x] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
