### PR TITLE
fix: validated camera head states in compute camera2body and small co…

### DIFF
--- a/src/CommandAndStateMessageParser.cpp
+++ b/src/CommandAndStateMessageParser.cpp
@@ -53,16 +53,11 @@ void CommandAndStateMessageParser::validateAuxLightIntensity(string device_id)
 
 void CommandAndStateMessageParser::validateDepthAttitude(string device_id)
 {
-    validateFieldPresent(m_json_data["payload"]["devices"][device_id],
-        "depth",
-        device_id);
-    validateFieldPresent(m_json_data["payload"]["devices"][device_id], "roll", device_id);
-    validateFieldPresent(m_json_data["payload"]["devices"][device_id],
-        "pitch",
-        device_id);
-    validateFieldPresent(m_json_data["payload"]["devices"][device_id],
-        "heading",
-        device_id);
+    auto root = m_json_data["payload"]["devices"][device_id];
+    validateFieldPresent(root, "depth", "payload/devices/" + device_id);
+    validateFieldPresent(root, "roll", "payload/devices/" + device_id);
+    validateFieldPresent(root, "pitch", "payload/devices/" + device_id);
+    validateFieldPresent(root, "heading", "payload/devices/" + device_id);
 }
 
 void CommandAndStateMessageParser::validateMotorStates(string device_id,
@@ -626,6 +621,7 @@ RigidBodyState CommandAndStateMessageParser::getCameraHeadTiltMotorStateRBS(
 
 Angle CommandAndStateMessageParser::computeCameraHead2BodyTilt(string address)
 {
+    validateCameraHeadStates(address);
     validateDepthAttitude(address);
 
     auto root = m_json_data["payload"]["devices"][address];
@@ -759,4 +755,8 @@ string CommandAndStateMessageParser::getRequestForRevolutionCameraHead(
 
     Json::FastWriter writer;
     return writer.write(request);
+}
+
+Json::Value CommandAndStateMessageParser::getJson() const {
+    return m_json_data;
 }

--- a/src/CommandAndStateMessageParser.hpp
+++ b/src/CommandAndStateMessageParser.hpp
@@ -133,8 +133,10 @@ namespace deep_trekker {
             std::string device_id);
         std::string getRequestForRevolutionPoseZAttitude(std::string api_version,
             std::string device_id);
-	std::string getRequestForRevolutionCameraHead(std::string api_version,
-    	    std::string device_id);
+        std::string getRequestForRevolutionCameraHead(std::string api_version,
+                std::string device_id);
+
+        Json::Value getJson() const;
 
     private:
         Json::Value m_json_data;


### PR DESCRIPTION
…de improvements

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->

Validate the camera head states when computing camera2body.

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
