### PR TITLE
feat: add powered reel current and pwm to get request

### DIFF
--- a/src/CommandAndStateMessageParser.cpp
+++ b/src/CommandAndStateMessageParser.cpp
@@ -710,7 +710,11 @@ string CommandAndStateMessageParser::getRequestForPoweredReelStates(string api_v
     device["acConnected"] = false;
     device["eStop"] = false;
     device["motor1Diagnostics"]["overcurrent"] = false;
+    device["motor1Diagnostics"]["current"] = 0;
+    device["motor1Diagnostics"]["pwm"] = 0;
     device["motor2Diagnostics"]["overcurrent"] = false;
+    device["motor2Diagnostics"]["current"] = 0;
+    device["motor2Diagnostics"]["pwm"] = 0;
     request["payload"]["devices"][device_id] = device;
 
     Json::FastWriter writer;

--- a/test/test_CommandAndStateMessageParser.cpp
+++ b/test/test_CommandAndStateMessageParser.cpp
@@ -681,8 +681,12 @@ TEST_F(MessageParserTest, it_creates_a_get_request_for_the_powered_reel_states)
     expected_json["payload"]["devices"]["abcd"]["eStop"] = false;
     expected_json["payload"]["devices"]["abcd"]["motor1Diagnostics"]["overcurrent"] =
         false;
+    expected_json["payload"]["devices"]["abcd"]["motor1Diagnostics"]["pwm"] = 0;
+    expected_json["payload"]["devices"]["abcd"]["motor1Diagnostics"]["current"] = 0;
     expected_json["payload"]["devices"]["abcd"]["motor2Diagnostics"]["overcurrent"] =
         false;
+    expected_json["payload"]["devices"]["abcd"]["motor2Diagnostics"]["pwm"] = 0;
+    expected_json["payload"]["devices"]["abcd"]["motor2Diagnostics"]["current"] = 0;
 
     auto message = parser.getRequestForPoweredReelStates("0.20.0", "abcd");
 


### PR DESCRIPTION

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
The driver default update frequency is 500ms, we use the get requests to request more frequent updates. Right now, the reel motors' current and pwm werent included in the udpates. This fixes that.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
